### PR TITLE
Add admin notice and redirect for unconfigured plugin

### DIFF
--- a/debughawk.php
+++ b/debughawk.php
@@ -4,6 +4,7 @@
  * Plugin URI: https://debughawk.com/
  * Description: WordPress performance monitoring and debugging.
  * Author: DebugHawk
+ * Author URI: https://debughawk.com/
  * Version: 1.1.1
  * Requires PHP: 7.4
  * Requires WP: 6.3

--- a/debughawk.php
+++ b/debughawk.php
@@ -5,7 +5,7 @@
  * Description: WordPress performance monitoring and debugging.
  * Author: DebugHawk
  * Author URI: https://debughawk.com/
- * Version: 1.1.1
+ * Version: 1.2.0
  * Requires PHP: 7.4
  * Requires WP: 6.3
  * License: GPLv3
@@ -24,7 +24,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 $config  = defined( 'DEBUGHAWK_CONFIG' ) ? DEBUGHAWK_CONFIG : [];
-$version = '1.1.1';
+$version = '1.2.0';
 
 ( new Plugin(
 	new Config( $config, __FILE__, $version ),

--- a/debughawk.php
+++ b/debughawk.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: DebugHawk
  * Plugin URI: https://debughawk.com/
- * Description: WordPress performance debugging and monitoring, simplified.
+ * Description: WordPress performance monitoring and debugging.
  * Author: DebugHawk
  * Version: 1.1.1
  * Requires PHP: 7.4

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: A5hleyRich
 Tags: performance, monitoring, debug, slow, speed, database, queries, core web vitals, optimization, profiling, cache, site health
 Tested up to: 6.9
-Stable tag: 1.1.1
+Stable tag: 1.2.0
 Requires at least: 6.3
 Requires PHP: 7.4
 License: GPLv3
@@ -148,6 +148,11 @@ DebugHawk automatically tracks all database queries, showing you slow queries, d
 
 == Changelog ==
 
+= 1.2.0 =
+* Added welcome notice for new installations guiding users to configuration
+* Automatically redirect to settings page on first activation
+* Added Author URI to plugin header for better discoverability
+
 = 1.1.1 =
 * Ensure db.php drop-in is updated and removed on plugin deactivation
 
@@ -177,6 +182,9 @@ DebugHawk automatically tracks all database queries, showing you slow queries, d
 * Object cache and page cache effectiveness
 
 == Upgrade Notice ==
+
+= 1.2.0 =
+Improved onboarding experience with welcome notice and automatic redirect to settings for new installations.
 
 = 1.1.1 =
 Important update: Ensures db.php drop-in is properly managed during plugin deactivation.

--- a/readme.txt
+++ b/readme.txt
@@ -151,7 +151,6 @@ DebugHawk automatically tracks all database queries, showing you slow queries, d
 = 1.2.0 =
 * Added welcome notice for new installations guiding users to configuration
 * Automatically redirect to settings page on first activation
-* Added Author URI to plugin header for better discoverability
 
 = 1.1.1 =
 * Ensure db.php drop-in is updated and removed on plugin deactivation
@@ -182,9 +181,6 @@ DebugHawk automatically tracks all database queries, showing you slow queries, d
 * Object cache and page cache effectiveness
 
 == Upgrade Notice ==
-
-= 1.2.0 =
-Improved onboarding experience with welcome notice and automatic redirect to settings for new installations.
 
 = 1.1.1 =
 Important update: Ensures db.php drop-in is properly managed during plugin deactivation.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -93,6 +93,9 @@ class Plugin {
 	}
 
 	public function deactivate(): void {
+		// Clear dismissed notice state for all users
+		delete_metadata( 'user', 0, 'debughawk_notice_dismissed', '', true );
+
 		$db_file = WP_CONTENT_DIR . '/db.php';
 
 		if ( ! file_exists( $db_file ) ) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -85,6 +85,11 @@ class Plugin {
 		if ( is_writable( WP_CONTENT_DIR ) && ! file_exists( $db_file ) ) {
 			copy( plugin_dir_path( $this->config->path ) . 'wp-content/db.php', $db_file );
 		}
+
+		// Redirect to settings page on activation if not configured
+		if ( ! $this->config->configured() ) {
+			set_transient( 'debughawk_activation_redirect', true, 30 );
+		}
 	}
 
 	public function deactivate(): void {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -93,7 +93,7 @@ class Plugin {
 	}
 
 	public function deactivate(): void {
-		// Clear dismissed notice state for all users
+		// Clear dismissed notice state for all users (object_id is ignored when delete_all is true)
 		delete_metadata( 'user', 0, 'debughawk_notice_dismissed', '', true );
 
 		$db_file = WP_CONTENT_DIR . '/db.php';

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -323,6 +323,10 @@ class Settings {
 	}
 
 	public function ajax_dismiss_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized', 403 );
+		}
+
 		check_ajax_referer( 'debughawk_dismiss_notice', 'nonce' );
 		update_user_meta( get_current_user_id(), 'debughawk_notice_dismissed', true );
 		wp_send_json_success();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -7,6 +7,10 @@ class Settings {
 	private const PAGE_SLUG = 'debughawk';
 	private const SETTINGS_GROUP = 'debughawk_settings_group';
 
+	private const DASHBOARD_URL = 'https://eu.debughawk.com';
+	private const DOCS_URL = 'https://debughawk.com/docs';
+	private const WEBSITE_URL = 'https://debughawk.com';
+
 	private Config $config;
 	private bool $has_constant;
 	private array $constant_config;
@@ -49,7 +53,7 @@ class Settings {
 
 		add_settings_section(
 			'debughawk_main_section',
-			__( 'DebugHawk Configuration', 'debughawk' ),
+			'',
 			[ $this, 'render_section_description' ],
 			self::PAGE_SLUG
 		);
@@ -84,7 +88,15 @@ class Settings {
 
 			<?php if ( $this->has_constant ): ?>
                 <div class="notice notice-info">
-                    <p><?php esc_html_e( 'Your settings are managed in wp-config.php via the DEBUGHAWK_CONFIG constant.', 'debughawk' ); ?></p>
+                    <p>
+						<?php
+						printf(
+							/* translators: %s: Link to configuration docs */
+							esc_html__( 'Settings are managed via the DEBUGHAWK_CONFIG constant in wp-config.php. %s', 'debughawk' ),
+							'<a href="' . esc_url( $this->tracked_url( self::DOCS_URL . '/configuration', 'settings-page', 'wp-config-notice' ) ) . '" target="_blank">' . esc_html__( 'Learn more', 'debughawk' ) . '</a>'
+						);
+						?>
+					</p>
                 </div>
 			<?php endif; ?>
 
@@ -98,13 +110,36 @@ class Settings {
 				}
 				?>
             </form>
+
+			<p class="description">
+				<a href="<?php echo esc_url( $this->tracked_url( self::DOCS_URL, 'settings-page', 'footer-docs' ) ); ?>" target="_blank"><?php esc_html_e( 'Documentation', 'debughawk' ); ?></a>
+				&nbsp;&bull;&nbsp;
+				<a href="<?php echo esc_url( $this->tracked_url( self::DASHBOARD_URL, 'settings-page', 'footer-dashboard' ) ); ?>" target="_blank"><?php esc_html_e( 'Open Dashboard', 'debughawk' ); ?></a>
+				&nbsp;&bull;&nbsp;
+				<a href="<?php echo esc_url( $this->tracked_url( self::WEBSITE_URL, 'settings-page', 'footer-website' ) ); ?>" target="_blank"><?php esc_html_e( 'debughawk.com', 'debughawk' ); ?></a>
+			</p>
         </div>
 		<?php
 	}
 
 	public function render_section_description(): void {
 		?>
-        <p><?php esc_html_e( 'Enter your endpoint and secret key from your DebugHawk dashboard to start monitoring your site\'s performance.', 'debughawk' ); ?></p>
+		<p>
+			<?php
+			printf(
+				/* translators: %s: Link to DebugHawk dashboard */
+				esc_html__( 'Enter your endpoint and secret key from your %s to start monitoring this site.', 'debughawk' ),
+				'<a href="' . esc_url( $this->tracked_url( self::DASHBOARD_URL, 'settings-page', 'section-description' ) ) . '" target="_blank">' . esc_html__( 'DebugHawk dashboard', 'debughawk' ) . '</a>'
+			);
+			?>
+			<?php
+			printf(
+				/* translators: %s: Link to getting started guide */
+				esc_html__( 'Need help? Read the %s.', 'debughawk' ),
+				'<a href="' . esc_url( $this->tracked_url( self::DOCS_URL . '/intro', 'settings-page', 'getting-started' ) ) . '" target="_blank">' . esc_html__( 'getting started guide', 'debughawk' ) . '</a>'
+			);
+			?>
+		</p>
 		<?php
 	}
 
@@ -182,18 +217,22 @@ class Settings {
 	}
 
 	private function render_field_description( string $field ): void {
+		$dashboard_link = '<a href="' . esc_url( $this->tracked_url( self::DASHBOARD_URL, 'settings-page', 'field-' . $field ) ) . '" target="_blank">' . esc_html__( 'DebugHawk dashboard', 'debughawk' ) . '</a>';
+
 		$descriptions = [
 			'enabled'                => __( 'Enable or disable DebugHawk monitoring.', 'debughawk' ),
-			'endpoint'               => __( 'Find this in your DebugHawk dashboard under Site Settings.', 'debughawk' ),
-			'secret'                 => __( 'Find this in your DebugHawk dashboard under Site Settings.', 'debughawk' ),
+			/* translators: %s: Link to DebugHawk dashboard */
+			'endpoint'               => sprintf( __( 'Find this in your %s under Site Settings.', 'debughawk' ), $dashboard_link ),
+			/* translators: %s: Link to DebugHawk dashboard */
+			'secret'                 => sprintf( __( 'Find this in your %s under Site Settings.', 'debughawk' ), $dashboard_link ),
 			'sample_rate'            => __( 'Percentage of requests to monitor (0-1). For example, 0.1 means 10% of requests.', 'debughawk' ),
 			'trace_admin_pages'      => __( 'Also monitor WordPress admin pages.', 'debughawk' ),
 			'trace_redirects'        => __( 'Also monitor redirect responses.', 'debughawk' ),
-			'slow_queries_threshold' => __( 'Queries taking longer than this will be flagged as slow.', 'debughawk' ),
+			'slow_queries_threshold' => __( 'Queries taking longer than this (in milliseconds) will be flagged as slow.', 'debughawk' ),
 		];
 
 		if ( isset( $descriptions[ $field ] ) ) {
-			echo '<p class="description">' . esc_html( $descriptions[ $field ] ) . '</p>';
+			echo '<p class="description">' . wp_kses( $descriptions[ $field ], [ 'a' => [ 'href' => [], 'target' => [] ] ] ) . '</p>';
 		}
 	}
 
@@ -265,9 +304,10 @@ class Settings {
 			<p>
 				<?php
 				printf(
-					/* translators: %s: URL to settings page */
-					esc_html__( 'Welcome to DebugHawk! %s to start monitoring your site\'s performance.', 'debughawk' ),
-					'<a href="' . esc_url( admin_url( 'options-general.php?page=' . self::PAGE_SLUG ) ) . '">' . esc_html__( 'Configure your settings', 'debughawk' ) . '</a>'
+					/* translators: %1$s: URL to settings page, %2$s: Link to getting started docs */
+					esc_html__( 'Welcome to DebugHawk! %1$s to start monitoring your site\'s performance, or %2$s.', 'debughawk' ),
+					'<a href="' . esc_url( admin_url( 'options-general.php?page=' . self::PAGE_SLUG ) ) . '">' . esc_html__( 'Configure your settings', 'debughawk' ) . '</a>',
+					'<a href="' . esc_url( $this->tracked_url( self::DOCS_URL . '/intro', 'admin-notice', 'welcome' ) ) . '" target="_blank">' . esc_html__( 'read the getting started guide', 'debughawk' ) . '</a>'
 				);
 				?>
 			</p>
@@ -277,5 +317,26 @@ class Settings {
 
 	public static function get_settings(): array {
 		return get_option( self::OPTION_NAME, [] );
+	}
+
+	/**
+	 * Build a tracked URL with UTM parameters for Fathom analytics.
+	 *
+	 * @param string $base_url The base URL (use class constants).
+	 * @param string $campaign The campaign name (e.g., 'settings-page', 'admin-notice').
+	 * @param string $content  Optional content identifier for A/B testing or link differentiation.
+	 */
+	private function tracked_url( string $base_url, string $campaign, string $content = '' ): string {
+		$params = [
+			'utm_source'   => 'wordpress-plugin',
+			'utm_medium'   => 'plugin',
+			'utm_campaign' => $campaign,
+		];
+
+		if ( $content ) {
+			$params['utm_content'] = $content;
+		}
+
+		return $base_url . '?' . http_build_query( $params );
 	}
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -256,6 +256,10 @@ class Settings {
 	}
 
 	public function admin_notice_unconfigured(): void {
+		// Don't show the notice on the settings page itself
+		if ( isset( $_GET['page'] ) && $_GET['page'] === self::PAGE_SLUG ) {
+			return;
+		}
 		?>
 		<div class="notice notice-info">
 			<p>

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -224,9 +224,9 @@ class Settings {
 		$descriptions = [
 			'enabled'                => __( 'Enable or disable DebugHawk monitoring.', 'debughawk' ),
 			/* translators: %s: Link to DebugHawk dashboard */
-			'endpoint'               => sprintf( __( 'Find this in your %s under Site Settings.', 'debughawk' ), $dashboard_link ),
+			'endpoint'               => sprintf( __( 'Find this in your %s.', 'debughawk' ), $dashboard_link ),
 			/* translators: %s: Link to DebugHawk dashboard */
-			'secret'                 => sprintf( __( 'Find this in your %s under Site Settings.', 'debughawk' ), $dashboard_link ),
+			'secret'                 => sprintf( __( 'Find this in your %s.', 'debughawk' ), $dashboard_link ),
 			'sample_rate'            => __( 'Percentage of requests to monitor (0-1). For example, 0.1 means 10% of requests.', 'debughawk' ),
 			'trace_admin_pages'      => __( 'Also monitor WordPress admin pages.', 'debughawk' ),
 			'trace_redirects'        => __( 'Also monitor redirect responses.', 'debughawk' ),

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -58,8 +58,8 @@ class Settings {
 		$this->add_settings_field( 'endpoint', __( 'Endpoint URL', 'debughawk' ), 'render_text_field' );
 		$this->add_settings_field( 'secret', __( 'Secret Key', 'debughawk' ), 'render_password_field' );
 		$this->add_settings_field( 'sample_rate', __( 'Sample Rate', 'debughawk' ), 'render_number_field' );
-		$this->add_settings_field( 'trace_admin_pages', __( 'Trace Admin Pages', 'debughawk' ), 'render_checkbox_field' );
-		$this->add_settings_field( 'trace_redirects', __( 'Trace Redirects', 'debughawk' ), 'render_checkbox_field' );
+		$this->add_settings_field( 'trace_admin_pages', __( 'Monitor Admin Pages', 'debughawk' ), 'render_checkbox_field' );
+		$this->add_settings_field( 'trace_redirects', __( 'Monitor Redirects', 'debughawk' ), 'render_checkbox_field' );
 		$this->add_settings_field( 'slow_queries_threshold', __( 'Slow Queries Threshold (ms)', 'debughawk' ), 'render_number_field' );
 	}
 
@@ -84,7 +84,7 @@ class Settings {
 
 			<?php if ( $this->has_constant ): ?>
                 <div class="notice notice-info">
-                    <p><?php esc_html_e( 'DebugHawk is configured via the DEBUGHAWK_CONFIG constant in wp-config.php. Settings on this page are disabled.', 'debughawk' ); ?></p>
+                    <p><?php esc_html_e( 'Your settings are managed in wp-config.php via the DEBUGHAWK_CONFIG constant.', 'debughawk' ); ?></p>
                 </div>
 			<?php endif; ?>
 
@@ -104,7 +104,7 @@ class Settings {
 
 	public function render_section_description(): void {
 		?>
-        <p><?php esc_html_e( 'Configure DebugHawk to monitor your WordPress site performance.', 'debughawk' ); ?></p>
+        <p><?php esc_html_e( 'Enter your endpoint and secret key from your DebugHawk dashboard to start monitoring your site\'s performance.', 'debughawk' ); ?></p>
 		<?php
 	}
 
@@ -184,12 +184,12 @@ class Settings {
 	private function render_field_description( string $field ): void {
 		$descriptions = [
 			'enabled'                => __( 'Enable or disable DebugHawk monitoring.', 'debughawk' ),
-			'endpoint'               => __( 'The URL endpoint where performance data will be sent.', 'debughawk' ),
-			'secret'                 => __( 'Secret key for encrypting data before transmission.', 'debughawk' ),
+			'endpoint'               => __( 'Find this in your DebugHawk dashboard under Site Settings.', 'debughawk' ),
+			'secret'                 => __( 'Find this in your DebugHawk dashboard under Site Settings.', 'debughawk' ),
 			'sample_rate'            => __( 'Percentage of requests to monitor (0-1). For example, 0.1 means 10% of requests.', 'debughawk' ),
-			'trace_admin_pages'      => __( 'Include WordPress admin pages in monitoring.', 'debughawk' ),
-			'trace_redirects'        => __( 'Monitor redirect responses.', 'debughawk' ),
-			'slow_queries_threshold' => __( 'Database queries taking longer than this (in milliseconds) are considered slow.', 'debughawk' ),
+			'trace_admin_pages'      => __( 'Also monitor WordPress admin pages.', 'debughawk' ),
+			'trace_redirects'        => __( 'Also monitor redirect responses.', 'debughawk' ),
+			'slow_queries_threshold' => __( 'Queries taking longer than this will be flagged as slow.', 'debughawk' ),
 		];
 
 		if ( isset( $descriptions[ $field ] ) ) {
@@ -266,7 +266,7 @@ class Settings {
 				<?php
 				printf(
 					/* translators: %s: URL to settings page */
-					esc_html__( 'Welcome to DebugHawk! %s to start seeing performance insights from your WordPress site.', 'debughawk' ),
+					esc_html__( 'Welcome to DebugHawk! %s to start monitoring your site\'s performance.', 'debughawk' ),
 					'<a href="' . esc_url( admin_url( 'options-general.php?page=' . self::PAGE_SLUG ) ) . '">' . esc_html__( 'Configure your settings', 'debughawk' ) . '</a>'
 				);
 				?>

--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://debughawk.com/
  * Description: Database drop-in for DebugHawk to capture database metrics and slow queries.
  * Author: DebugHawk
- * Version: 1.1.1
+ * Version: 1.2.0
  * Requires PHP: 7.4
  * Requires WP: 6.3
  * License: GPLv3


### PR DESCRIPTION
## Summary

- Adds a welcome notice on admin pages when DebugHawk is not configured, guiding users to the settings page
- Automatically redirects to settings page on first activation for streamlined onboarding
- Notice disappears once the plugin is configured (via UI or `DEBUGHAWK_CONFIG` constant)

## Test plan

- [ ] Activate plugin without any configuration and verify redirect to settings page
- [ ] Navigate away from settings without configuring and verify notice appears on other admin pages
- [ ] Configure plugin and verify notice disappears
- [ ] Bulk activate multiple plugins including DebugHawk and verify no redirect occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)